### PR TITLE
Update build.gradle Android Gradle plugin alpha10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha09'
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha10'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Updated the Android Gradle plugin to 7.0.0-alpha10 to work with Android Studio Arctic Fox Canary 10 (2020.3.1.10)